### PR TITLE
Tractogram import menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
-# python_blender
+# Tractography loader for Blender 3D
 
-The easiest way to work with brain tractography within Blender 3D is to either load them as tck and trk file (from DiPy o MRITRIX) or to compute them directly from the Python console of Blender.
+The easiest way to work with brain tractography within Blender 3D is to either load them from .tck or .trk files (from DIPY or MRTRIX) or to compute them directly from Blender's Python console.
  
 <img src="https://github.com/alecrimi/python_blender/blob/main/Capture_TRK.PNG"  height="200"> 
 <img src="https://github.com/alecrimi/python_blender/blob/main/Capture_Blender.PNG"   height="200">
 
-First you need to installed the needed library (see script install_libs.py), this might not work for all system and you need to find where is the command for the Python interpreter of Blender (not the Python you are using in the system).
+## Setup
+
+First, you need to make sure that Blender has access to the path where you will want to install some dependencies. To know what are the valid paths in your system type the following commands in Blender's python console:
+
+```python
+import sys
+print(sys.path)
+```
+
+You should see something like this:
+
+<img src="https://user-images.githubusercontent.com/9929496/213748854-13fa18b7-4b55-48d2-8781-3006b40b6a75.png">
+
+ Next, execute the script `install_libs.py` which will install the required libraries. This might not work for all systems so, make sure that these dependencies are present in one of the paths (`sys.path`) to which Blender has access.
 
 Then you need to load the streamlines and convert them into NURBS or anything that is Blender manageble.
+
 See the full explanation in the video below
 
 [![Using brain tractography with Nibabel or Dipy directly from Blender 3D](https://img.youtube.com/vi/ANkq9EAEEeI/0.jpg)](https://www.youtube.com/watch?v=ANkq9EAEEeI "Using brain tractography with Nibabel or Dipy directly from Blender 3D")
+
+## Installation
+
+For ease of use we have included the script `import_tractogram.py` that adds the menu item **Tractogram (.trk)** to the **File** > **Import** menu.
+
+<img src="https://user-images.githubusercontent.com/9929496/213745671-9b84c624-0ab2-463a-93de-dc9c6e21dc50.png">
+
+To install it, import the script in Blender's text editor and execute it.

--- a/import_tractogram.py
+++ b/import_tractogram.py
@@ -1,0 +1,81 @@
+import bpy
+import nibabel as nib
+import numpy as np
+import os
+
+from bpy.props import StringProperty
+from bpy.types import Operator
+from bpy_extras.io_utils import ImportHelper
+
+
+def load_tractogram(context, filepath):
+    print('Attempting to load tractogram: {}'.format(filepath))
+    filename = os.path.splitext(os.path.basename(filepath))[0]
+    print('Loading file...')
+    data = nib.streamlines.load(filepath)
+    # Access the streamline data
+    print('Accessing data...')
+    streamlines = list(data.streamlines)
+    # Accessing a custom collection
+    print('Accessing "{}" collection...'.format(filename))
+    if (bpy.data.collections.find(filename) == True):
+        sls_col = bpy.data.collections[filename]
+    else:
+        sls_col = bpy.data.collections.new(filename)
+        bpy.context.scene.collection.children.link(sls_col)
+    # Iterate over the streamlines
+    print('Converting lines to NURBS...')
+    for i, sl in enumerate(streamlines):
+        # Create a new curve object
+        curve = bpy.data.curves.new(name='Streamline {}'.format(i), type='CURVE')
+        curve.dimensions = '3D'
+        # Create a new curve spline
+        spline = curve.splines.new('NURBS')
+        spline.points.add(len(sl) - 1)
+        # Set the control points of the spline
+        for j, point in enumerate(sl):
+            spline.points[j].co = np.append(point, 1)
+        # Create an object for the curve and link it to the scene
+        obj = bpy.data.objects.new('Streamline {}'.format(i), curve)
+        sls_col.objects.link(obj)
+    print('Tractogram loaded')
+    return {'FINISHED'}
+
+
+class TractogramImportHelper(Operator, ImportHelper):
+    """This appears in the tooltip of the operator and in the generated docs"""
+    # Important since its how bpy.ops.import_helper.tractogram is constructed
+    bl_idname = 'import_helper.tractogram'
+    bl_label = 'Import tractogram'
+    
+    # ImportHelper mixin class uses this
+    filename_ext = ".trk"
+    
+    filter_glob: StringProperty(
+        default='*.trk',
+        options={'HIDDEN'},
+    )
+    
+    # List of operator properties, the attributes will be assigned to the class instance
+    # from the operator settings before calling
+    
+    def execute(self, context):
+        return load_tractogram(context, self.filepath)
+
+# Only needed if you want to add into a dynamic menu
+def menu_func_import(self, context):
+    self.layout.operator(TractogramImportHelper.bl_idname, text='Tractogram (.trk)')
+
+    
+def register():
+    bpy.utils.register_class(TractogramImportHelper)
+    bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
+
+
+def unregister():
+    bpy.utils.unregister_class(TractogramImportHelper)
+    bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
+
+
+if __name__ == '__main__':
+    register()


### PR DESCRIPTION
This PR adds the menu option to import tractograms (.trk files) through the File > Import menu.

The added menu item looks like this:

![blender_dmri1](https://user-images.githubusercontent.com/9929496/213745671-9b84c624-0ab2-463a-93de-dc9c6e21dc50.png)
